### PR TITLE
Change roleBinding type (reduce scope of query to namespace)

### DIFF
--- a/pkg/controller/gitopscluster/gitopscluster_controller.go
+++ b/pkg/controller/gitopscluster/gitopscluster_controller.go
@@ -555,7 +555,7 @@ func (r *ReconcileGitOpsCluster) CreateApplicationSetRbac(namespace string) erro
 		}
 	}
 
-	err = r.Get(context.Background(), types.NamespacedName{Name: ROLEBINDINGNAME, Namespace: namespace}, &rbacv1.ClusterRoleBinding{})
+	err = r.Get(context.Background(), types.NamespacedName{Name: ROLEBINDINGNAME, Namespace: namespace}, &rbacv1.RoleBinding{})
 	if k8errors.IsNotFound(err) {
 		klog.Infof("creating roleBinding %s, in namespace %s", ROLEBINDINGNAME, namespace)
 
@@ -572,6 +572,7 @@ func (r *ReconcileGitOpsCluster) CreateApplicationSetRbac(namespace string) erro
 func (r *ReconcileGitOpsCluster) GetManagedClusters(namespace string, placementref v1.ObjectReference) ([]string, error) {
 	if placementref.Kind != "Placement" ||
 		placementref.APIVersion != "cluster.open-cluster-management.io/v1alpha1" {
+		klog.Error("Invalid Kind or APIVersion, must be \"Placement\" and \"cluster.open-cluster-management.io/v1alpha1\"")
 		return nil, errInvalidPlacementRef
 	}
 


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

1. The get is for the incorrect ClusterRoleBinding type, which is showing an error message and trying to create a duplicate resource.  This doesn't cause a real failure today because we absorb the create error. The code should not be trying to create the roleBinding each time.
2. Added a log message for a problem QE was seeing when the APIVersion was incorrect. Currently there is no error message
3. Even though the ClusterRole is changed to a Role, the serviceAccount already has access (we create a RoleBinding in the next step)